### PR TITLE
fix kernel_logger_name with /permisive-

### DIFF
--- a/src/optick_core.win.h
+++ b/src/optick_core.win.h
@@ -1239,7 +1239,7 @@ CaptureStatus::Type ETW::Start(Mode::Type mode, int frequency, const ThreadList&
 		}
 
 		ZeroMemory(&logFile, sizeof(EVENT_TRACE_LOGFILE));
-		logFile.LoggerName = KERNEL_LOGGER_NAME;
+		logFile.LoggerName = const_cast<decltype(logFile.LoggerName)>(KERNEL_LOGGER_NAME);
 		logFile.ProcessTraceMode = (PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP);
 		logFile.EventRecordCallback = OnRecordEvent;
 		logFile.BufferCallback = OnBufferRecord;


### PR DESCRIPTION
Hi again,
I apologize for the forgotten (LPSTR) cast hotfix that has sneaked into my previous PR :(
Anyway, when compiling with /permisive-, which forces visual studio to be more conformant with c++ standard, it fails on assigning const pointer to non-const variable. This PR does a proper fix.
There are also few fixed line endings. I hope that is ok.
