### PR TITLE
Added ifndef guard to NOMINMAX

### DIFF
--- a/src/optick_common.h
+++ b/src/optick_common.h
@@ -16,7 +16,9 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <windows.h>
 #endif
 


### PR DESCRIPTION
Some projects may define NOMINMAX globally - this will stop optick from killing them