### PR TITLE
Fixed C2440 in C++17 /permissive- conformance mode

### DIFF
--- a/src/optick_core.win.h
+++ b/src/optick_core.win.h
@@ -1239,7 +1239,7 @@ CaptureStatus::Type ETW::Start(Mode::Type mode, int frequency, const ThreadList&
 		}
 
 		ZeroMemory(&logFile, sizeof(EVENT_TRACE_LOGFILE));
-		logFile.LoggerName = KERNEL_LOGGER_NAME;
+		logFile.LoggerName = const_cast<LPSTR>(KERNEL_LOGGER_NAME);
 		logFile.ProcessTraceMode = (PROCESS_TRACE_MODE_REAL_TIME | PROCESS_TRACE_MODE_EVENT_RECORD | PROCESS_TRACE_MODE_RAW_TIMESTAMP);
 		logFile.EventRecordCallback = OnRecordEvent;
 		logFile.BufferCallback = OnBufferRecord;


### PR DESCRIPTION
`const_cast` could be a code smell but I wanted to unblock this quickly.