### PR TITLE
Add cmake install so that Optick can be found through FindPackage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.2)
-project(Optick LANGUAGES CXX)
+project(Optick LANGUAGES CXX VERSION 1.3.0)
 
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
@@ -43,8 +43,16 @@ option(OPTICK_BUILD_CONSOLE_SAMPLE "Build Optick console sample app" ${standalon
 
 # OptickCore
 add_library(OptickCore SHARED ${OPTICK_SRC})
-target_include_directories(OptickCore PUBLIC "src")
-target_compile_definitions(OptickCore PUBLIC OPTICK_EXPORTS=1)
+target_include_directories(OptickCore
+	PUBLIC
+		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+)
+set_target_properties(OptickCore 
+	PROPERTIES 
+		PUBLIC_HEADER "${CMAKE_CURRENT_SOURCE_DIR}/src/optick.h;${CMAKE_CURRENT_SOURCE_DIR}/src/optick.config.h"
+		DEBUG_POSTFIX d # So that we can install debug and release side by side
+)
+target_compile_definitions(OptickCore PRIVATE OPTICK_EXPORTS=1)
 if(OPTICK_USE_VULKAN)
 	message(STATUS "Optick uses Vulkan")
 	target_include_directories(OptickCore PRIVATE "$(VULKAN_SDK)/Include")
@@ -88,4 +96,56 @@ if(OPTICK_BUILD_CONSOLE_SAMPLE)
 	target_link_libraries(ConsoleApp ${EXTRA_LIBS})
 	set_target_properties(ConsoleApp PROPERTIES FOLDER Samples)
 endif()
+
+
+
+###############
+## Packaging ##
+###############
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+set(${PROJECT_NAME}_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE STRING "Path to smartcrop cmake files")
+
+# Use version checking boilerplate
+write_basic_package_version_file(
+	${PROJECT_NAME}ConfigVersion.cmake
+	COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+	${PROJECT_SOURCE_DIR}/tools/${PROJECT_NAME}Config.cmake.in
+	${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+	INSTALL_DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKEDIR} 
+	# Imported targets do not require the following macros
+	NO_SET_AND_CHECK_MACRO
+	NO_CHECK_REQUIRED_COMPONENTS_MACRO 
+)
+
+install(TARGETS OptickCore
+	EXPORT ${PROJECT_NAME}_Targets
+	RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
+	LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+
+)
+
+install(
+	EXPORT ${PROJECT_NAME}_Targets 
+	NAMESPACE ${PROJECT_NAME}::
+	FILE ${PROJECT_NAME}Targets.cmake
+	DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKEDIR}
+)
+
+
+install(FILES 
+	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+	DESTINATION
+		${${PROJECT_NAME}_INSTALL_CMAKEDIR}
+)
+
+
+
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,8 @@ source_group("OptickCore" FILES ${OPTICK_SRC})
 
 # Enabled
 option(OPTICK_ENABLED "Enable profiling with Optick" ON)
+option(OPTICK_INSTALL_TARGETS "Should optick be installed? Set to OFF if you use add_subdirectory to include Optick." ON)
+
 if(NOT OPTICK_ENABLED)
 	message(STATUS "Optick is disabled")
 	# add dummy target as a replacement
@@ -98,54 +100,54 @@ if(OPTICK_BUILD_CONSOLE_SAMPLE)
 endif()
 
 
-
 ###############
 ## Packaging ##
 ###############
-include(CMakePackageConfigHelpers)
-include(GNUInstallDirs)
+if(OPTICK_INSTALL_TARGETS)
+	include(CMakePackageConfigHelpers)
+	include(GNUInstallDirs)
 
-set(${PROJECT_NAME}_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE STRING "Path to smartcrop cmake files")
+	set(${PROJECT_NAME}_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE STRING "Path to smartcrop cmake files")
 
-# Use version checking boilerplate
-write_basic_package_version_file(
-	${PROJECT_NAME}ConfigVersion.cmake
-	COMPATIBILITY SameMajorVersion
-)
+	# Use version checking boilerplate
+	write_basic_package_version_file(
+		${PROJECT_NAME}ConfigVersion.cmake
+		COMPATIBILITY SameMajorVersion
+	)
 
-configure_package_config_file(
-	${PROJECT_SOURCE_DIR}/tools/${PROJECT_NAME}Config.cmake.in
-	${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-	INSTALL_DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKEDIR} 
-	# Imported targets do not require the following macros
-	NO_SET_AND_CHECK_MACRO
-	NO_CHECK_REQUIRED_COMPONENTS_MACRO 
-)
+	configure_package_config_file(
+		${PROJECT_SOURCE_DIR}/tools/${PROJECT_NAME}Config.cmake.in
+		${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+		INSTALL_DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKEDIR} 
+		# Imported targets do not require the following macros
+		NO_SET_AND_CHECK_MACRO
+		NO_CHECK_REQUIRED_COMPONENTS_MACRO 
+	)
 
-install(TARGETS OptickCore
-	EXPORT ${PROJECT_NAME}_Targets
-	RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
-	LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
-	INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+	install(TARGETS OptickCore
+		EXPORT ${PROJECT_NAME}_Targets
+		RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
+		LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+		INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 
-)
+	)
 
-install(
-	EXPORT ${PROJECT_NAME}_Targets 
-	NAMESPACE ${PROJECT_NAME}::
-	FILE ${PROJECT_NAME}Targets.cmake
-	DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKEDIR}
-)
+	install(
+		EXPORT ${PROJECT_NAME}_Targets 
+		NAMESPACE ${PROJECT_NAME}::
+		FILE ${PROJECT_NAME}Targets.cmake
+		DESTINATION ${${PROJECT_NAME}_INSTALL_CMAKEDIR}
+	)
 
 
-install(FILES 
-	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-	${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
-	DESTINATION
-		${${PROJECT_NAME}_INSTALL_CMAKEDIR}
-)
-
+	install(FILES 
+		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+		${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+		DESTINATION
+			${${PROJECT_NAME}_INSTALL_CMAKEDIR}
+	)
+endif()
 
 
 

--- a/tools/OptickConfig.cmake.in
+++ b/tools/OptickConfig.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+# Required so that on windows Release and RelWithDebInfo can be used instead of default fallback which is Debug
+# See https://gitlab.kitware.com/cmake/cmake/-/issues/20319
+set(CMAKE_MAP_IMPORTED_CONFIG_MINSIZEREL MinSizeRel RelWithDebInfo Release Debug)
+set(CMAKE_MAP_IMPORTED_CONFIG_RELWITHDEBINFO RelWithDebInfo Release MinSizeRel Debug)
+set(CMAKE_MAP_IMPORTED_CONFIG_RELEASE Release RelWithDebInfo MinSizeRel Debug)
+
+include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")


### PR DESCRIPTION
Those changes add installation to the CMakeLists.txt.
This way a user can build the `install` target and on the consumer side do for example:

```cmake
find_package(Optick CONFIG REQUIRED)
add_executable(test main.cpp)
target_link_libraries(test PRIVATE Optick::OptickCore)
```

Note that I had to add the version to the project command which will need to be kept up to date, and `SameMajorVersion` in `write_basic_package_version_file` assuming semantic versioning. If it is not the case, you can check https://cmake.org/cmake/help/latest/module/CMakePackageConfigHelpers.html#command:write_basic_package_version_file for the list of possible version compatibility modes.

Also, this should work on old versions of CMake, but I am not sure if all the other commands already used in the rest of the file are available in 3.2. It might be better to update the CMake required version (I'd suggest a minimum of 3.8, ideally 3.14). I tested this on CMake 3.14+ only.