### PR TITLE
[feat] Added toggle in thread view to show or hide vertical frame lines.

### DIFF
--- a/gui/Profiler.Controls/ThreadView/EventThreadView.xaml
+++ b/gui/Profiler.Controls/ThreadView/EventThreadView.xaml
@@ -88,6 +88,9 @@
                         </StackPanel>
                     </ToggleButton.Content>
                 </ToggleButton>
+                <ToggleButton x:Name="ShowFrameLinesButton" ToolTip="Show Frame Lines" Height="{StaticResource DefaultButtonSize}" Margin="0,0,1,0" Click="ShowFrameLinesButton_Click" IsChecked="{Binding ShowFrameLines, ElementName=ThreadViewControl}">
+                    <TextBlock Text="SHOW FRAMES" Margin="0,-3,0,0" Padding="0" />
+                </ToggleButton>
                 <Popup x:Name="CallstackFilterPopup" Placement="Bottom" IsOpen="{Binding IsChecked, ElementName=CallstackFilterDrowpdown}" PlacementTarget="{Binding ElementName=ShowCallstacksButton}" StaysOpen="False" >
                     <Border Background="{StaticResource OptickContentBackground}" BorderBrush="{StaticResource OptickBorder}" BorderThickness="1" Width="{Binding ActualWidth, ElementName=ShowCallstacksButton}">
                         <ItemsControl ItemsSource="{Binding}">

--- a/gui/Profiler.Controls/ThreadView/EventThreadView.xaml.cs
+++ b/gui/Profiler.Controls/ThreadView/EventThreadView.xaml.cs
@@ -549,6 +549,12 @@ namespace Profiler.Controls
 			ThreadViewControl.UpdateSurface();
 		}
 
+		private void ShowFrameLinesButton_Click(object sender, RoutedEventArgs e)
+		{
+			ThreadViewControl.ShowFrameLines = ShowFrameLinesButton.IsChecked.GetValueOrDefault(true);
+			ThreadViewControl.UpdateSurface();
+		}
+
 		private void CallstackFilterDrowpdown_Click(object sender, RoutedEventArgs e)
 		{
 			CallstackFilterPopup.IsOpen = true;

--- a/gui/Profiler.Controls/ThreadView/ThreadViewControl.xaml.cs
+++ b/gui/Profiler.Controls/ThreadView/ThreadViewControl.xaml.cs
@@ -56,6 +56,7 @@ namespace Profiler.Controls
 		}
 
 		public bool ShowThreadHeaders { get; set; } = true;
+		public bool ShowFrameLines { get; set; } = true;
 
 		Mesh BackgroundMesh { get; set; }
 		Mesh ForegroundMesh { get; set; }
@@ -571,7 +572,7 @@ namespace Profiler.Controls
 
 			if (layer == DirectXCanvas.Layer.Foreground)
 			{
-				if (ForegroundMesh != null)
+				if (ShowFrameLines && ForegroundMesh != null)
 				{
 					Matrix world = new Matrix(Scroll.Zoom, 0.0, 0.0, 1.0, -Scroll.ViewUnit.Left * Scroll.Zoom, 0.0);
 					ForegroundMesh.WorldTransform = world;


### PR DESCRIPTION
This makes it easier to view profiling data for long-running tasks that are mostly independent of individual frames.  Otherwise, the vertical frame lines overlap the text, which is especially bad when zooming out so that hundreds of frames fit within the view width.

Example of a profile run during game loading, showing frame lines as in current version:
![optick-load-demo-show-frames](https://user-images.githubusercontent.com/7810015/89504769-dda17b00-d7c8-11ea-8bda-6859624897f7.png)

And the same with the toggle to show frames turned off:
![optick-load-demo-hide-frames](https://user-images.githubusercontent.com/7810015/89504825-f3af3b80-d7c8-11ea-9666-4aef3ec0f974.png)
