### PR TITLE
MinGW Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,12 @@ if(MSVC)
 	target_compile_definitions(OptickCore PRIVATE _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS)
 endif()
 
+if(NOT MSVC)
+	if(WIN32)
+		target_link_libraries(OptickCore PRIVATE ws2_32 dbghelp)
+	endif()
+endif()
+
 set(EXTRA_LIBS ${EXTRA_LIBS} OptickCore)
 if(NOT MSVC)
 	set(EXTRA_LIBS ${EXTRA_LIBS} pthread)

--- a/samples/Common/TestEngine/TestEngine.cpp
+++ b/samples/Common/TestEngine/TestEngine.cpp
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <vector>
 #include <cstring>
+#include <cstdio>
 
 #if OPTICK_ENABLE_FIBERS
 #include <MTProfilerEventListener.h>

--- a/src/optick.h
+++ b/src/optick.h
@@ -38,14 +38,17 @@
 #		define OPTICK_LINUX (1)
 #	elif defined(__FreeBSD__)
 #		define OPTICK_FREEBSD (1)
-#	endif
+#	elif defined(_WIN32) || defined(WIN32)
+#       define OPTICK_MINGW (1)
+#       define OPTICK_PC (1)
+#   endif
 #elif defined(_MSC_VER)
 #	define OPTICK_MSVC (1)
 #	if defined(_DURANGO)
 #		define OPTICK_PC (0)
 #	else
 #		define OPTICK_PC (1)
-#endif
+#   endif
 #else
 #error Compiler not supported
 #endif

--- a/src/optick.h
+++ b/src/optick.h
@@ -41,6 +41,12 @@
 #	elif defined(_WIN32) || defined(WIN32)
 #       define OPTICK_MINGW (1)
 #       define OPTICK_PC (1)
+#       include <sdkddkver.h>
+#       if WINVER < _WIN32_WINNT_WIN7 || _WIN32_WINNT < _WIN32_WINNT_WIN7
+#           error "Optik requires to compile at least for Windows 7, please upgrade MinGW windows "\
+#                 "SDK, or define WINVER and _WIN32_WINNT to _WIN32_WINNT_WIN7 or greater if your "\
+#                 "MinGW build supports it."
+#       endif
 #   endif
 #elif defined(_MSC_VER)
 #	define OPTICK_MSVC (1)

--- a/src/optick.h
+++ b/src/optick.h
@@ -38,7 +38,7 @@
 #		define OPTICK_LINUX (1)
 #	elif defined(__FreeBSD__)
 #		define OPTICK_FREEBSD (1)
-#	elif defined(_WIN32) || defined(WIN32)
+#	elif defined(__MINGW32__) || defined(__MINGW64__)
 #       define OPTICK_MINGW (1)
 #       define OPTICK_PC (1)
 #       include <sdkddkver.h>

--- a/src/optick.h
+++ b/src/optick.h
@@ -43,9 +43,9 @@
 #       define OPTICK_PC (1)
 #       include <sdkddkver.h>
 #       if WINVER < _WIN32_WINNT_WIN7 || _WIN32_WINNT < _WIN32_WINNT_WIN7
-#           error "Optik requires to compile at least for Windows 7, please upgrade MinGW windows "\
-#                 "SDK, or define WINVER and _WIN32_WINNT to _WIN32_WINNT_WIN7 or greater if your "\
-#                 "MinGW build supports it."
+#           error "Optick requires to compile at least for Windows 7, please upgrade MinGW windows \
+                  SDK, or define WINVER and _WIN32_WINNT to _WIN32_WINNT_WIN7 or greater if your \
+                  MinGW build supports it."
 #       endif
 #   endif
 #elif defined(_MSC_VER)

--- a/src/optick_common.h
+++ b/src/optick_common.h
@@ -34,10 +34,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#if defined(OPTICK_MSVC)
+#if defined(OPTICK_MSVC) || defined(OPTICK_MINGW)
 
-#ifdef OPTICK_UE4
-#include "Core/Public/Windows/AllowWindowsPlatformTypes.h"
+#if !defined(OPTICK_MINGW)
+#   ifdef OPTICK_UE4
+#   include "Core/Public/Windows/AllowWindowsPlatformTypes.h"
+#   endif
 #endif
 
 #ifndef WIN32_LEAN_AND_MEAN
@@ -48,8 +50,10 @@
 #endif
 #include <windows.h>
 
-#ifdef OPTICK_UE4
-#include "Core/Public/Windows/HideWindowsPlatformTypes.h"
+#if !defined(OPTICK_MINGW)
+#   ifdef OPTICK_UE4
+#   include "Core/Public/Windows/HideWindowsPlatformTypes.h"
+#   endif
 #endif
 
 #ifndef TRUE

--- a/src/optick_core.cpp
+++ b/src/optick_core.cpp
@@ -33,7 +33,7 @@
 //////////////////////////////////////////////////////////////////////////
 // Start of the Platform-specific stuff
 //////////////////////////////////////////////////////////////////////////
-#if defined(OPTICK_MSVC)
+#if defined(OPTICK_MSVC) || defined(OPTICK_MINGW)
 #include "optick_core.win.h"
 #elif defined(OPTICK_LINUX)
 #include "optick_core.linux.h"
@@ -826,7 +826,7 @@ void Core::DumpProgressFormatted(const char* format, ...)
 	va_list arglist;
 	char buffer[256] = { 0 };
 	va_start(arglist, format);
-#ifdef OPTICK_MSVC
+#if defined(OPTICK_MSVC) || defined(OPTICK_MINGW)
 	vsprintf_s(buffer, format, arglist);
 #else
 	vsprintf(buffer, format, arglist);
@@ -1885,20 +1885,28 @@ bool EndsWith(const char* str, const char* substr)
 OPTICK_API bool SaveCapture(const char* path, bool force /*= true*/)
 {
 	char filePath[512] = { 0 };
+#if defined(OPTICK_MINGW)
+	strcpy_s(filePath, path);
+#else
 	strcpy(filePath, path);
+#endif
 	
 	if (path == nullptr || !EndsWith(path, ".opt"))
 	{
 		time_t now = time(0);
 		struct tm tstruct;
-#if defined(OPTICK_MSVC)
+#if defined(OPTICK_MSVC) || defined(OPTICK_MINGW)
 		localtime_s(&tstruct, &now);
 #else
 		localtime_r(&now, &tstruct);
 #endif
 		char timeStr[80] = { 0 };
 		strftime(timeStr, sizeof(timeStr), "(%Y-%m-%d.%H-%M-%S).opt", &tstruct);
-		strcat(filePath, timeStr);
+#if defined(OPTICK_MINGW)
+		strcat_s(filePath, timeStr);
+#else
+        strcat(filePath, timeStr);
+#endif
 	}
 
 	SaveHelper::Init(filePath);

--- a/src/optick_core.win.h
+++ b/src/optick_core.win.h
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 #pragma once
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__) || defined(__MINGW64__)
 
 #include "optick.config.h"
 
@@ -1585,7 +1585,14 @@ void WinSymbolEngine::Init()
 		for (size_t i = 0; i < loadedModules.size(); ++i)
 		{
 			const Module& module = loadedModules[i];
+#if defined(__MINGW32__) || defined(__MINGW64__)
+            // Cast away const because mingw marks the param as char* not const char*
+			char* modulePath = (char*)module.path.c_str();
+			SymLoadModule64(hProcess, NULL, modulePath, NULL, (DWORD64)module.address, (DWORD)module.size);
+#else
 			SymLoadModule64(hProcess, NULL, module.path.c_str(), NULL, (DWORD64)module.address, (DWORD)module.size);
+#endif
+
 		}
 
 #else

--- a/src/optick_server.cpp
+++ b/src/optick_server.cpp
@@ -26,7 +26,7 @@
 #include "optick_common.h"
 #include "optick_miniz.h"
 
-#if defined(OPTICK_MSVC)
+#if defined(OPTICK_MSVC) || defined(OPTICK_MINGW)
 #define USE_WINDOWS_SOCKETS (1)
 #else
 #define USE_BERKELEY_SOCKETS (1)


### PR DESCRIPTION
Currently OptickCore only supports compiling for MSVC for Windows. This pull request extends support of the current code and CMake build system to allow compiling OptickCore with the MinGW toolchain as well.

My motivation for this pull request is to enable using the `x86_64-pc-windows-gnu` target with rustc and the rust bindings. Debugger support for `x86_64-pc-windows-gnu` is immensely stronger than on the `x86_64-pc-windows-msvc` target so it would be ideal for me to still be able to use the `gnu` target.

Very little changes were needed. Almost every change was related to correctly handling conditional compilation as `OPTICK_MSVC` as used in many places where a more appropriate name would be `OPTICK_WINDOWS` as it wasn't guarding MSVC features but windows features.

I have tested the code using the CMake build system with MSVC, MinGW 6.0, MinGW 8.0 (Trunk, from MSYS2) and Linux. To provide a breakdown
- MSVC: Build unchanged, all changes are behind `#if` guards so the behavior of the MSVC code should be unchanged.
- MinGW 8.0: Compiles seamlessly and tested as functional with ConsoleApp
- Linux: Same as MSVC, all changes are guarded by platform checks
- MinGW 6.0: Can work but will fail to compile unless `WINVER` and `_WIN32_WINNT` are defined globally to `_WIN32_WINNT_WIN7` or higher. Some of the ETW functions are only supported on Windows 7 or newer, and older MinGW builds have their headers default to `_WIN32_WINNT_WINXP` which is for Windows XP. In this case the functions are left undefined and the build will fail. In my preprocessor check I explicitly raise `WINVER` being too low to be an error with an `#error` directive. The solution, depending on how old your MinGW is either update the MinGW version being used or define `WINVER` and `_WIN32_WINNT` to 0x0601 (the value for `_WIN32_WINNT_WIN7`) with a compiler flag.
Manually defining `WINVER` and `_WIN32_WINNT` is the intended path for targeting a newer windows version than the default.

The only change which I could see as contentious is for commit `3777e24`. The `SymLoadModule64` is defined to take `char*` for the module path parameter on MinGW. I believe this to be an error in the MinGW headers as the official MSVC Windows SDK headers define the parameter to take a `const char*`. The value for that paramater is taken from `std::string.c_str()` which always returns a `const char*` so will cause a compilation error on MinGW.

Under the assumption the MinGW header is wrong and the underlying function will never write through the pointer I cast the const away, which is super unsafe but I believe my assumption to be correct. This could be marked as a workaround and investigated further in the future if needed.

I also fixed a missing include in TestEngine

