### PR TITLE
Remove waiting for screenshot when profiling dedicated ue server.

### DIFF
--- a/samples/UnrealEnginePlugin/Source/Private/OptickPlugin.cpp
+++ b/samples/UnrealEnginePlugin/Source/Private/OptickPlugin.cpp
@@ -370,7 +370,9 @@ bool FOptickPlugin::IsScreenshotReady() const
 
 bool FOptickPlugin::IsReadyToDumpCapture() const
 {
-	return IsScreenshotReady() || (GFrameNumber - WaitingForScreenshotFrameNumber) > WaitForScreenshotMaxFrameCount;
+	return	IsScreenshotReady() ||
+			(GFrameNumber - WaitingForScreenshotFrameNumber) > WaitForScreenshotMaxFrameCount ||
+			(GIsServer && !GIsClient);
 }
 
 void FOptickPlugin::OnScreenshotProcessed()
@@ -673,7 +675,7 @@ void FOptickPlugin::GetDataFromStatsThread(int64 CurrentFrame)
 					OPTICK_FRAME_FLIP(Optick::FrameType::CPU, Storage->LastTimestamp, Packet.ThreadId);
 				}
 			}
-			else if (Op == EStatOperation::AdvanceFrameEventRenderThread)
+			else if (Op == EStatOperation::AdvanceFrameEventRenderThread && (GIsClient || !GIsServer))
 			{
 				if (Storage->LastTimestamp != 0)
 				{


### PR DESCRIPTION
When profiling dedicated server optick is waiting for screenshot. And stall forever. This will pr will fix it.