### PR TITLE
Fix spelling mistake in optick.config.h

### DIFF
--- a/src/optick.config.h
+++ b/src/optick.config.h
@@ -62,7 +62,7 @@
 #endif
 #endif
 
-// VUKLAN
+// VULKAN
 #if !defined(OPTICK_ENABLE_GPU_VULKAN)
 #if defined(_MSC_VER)
 #define OPTICK_ENABLE_GPU_VULKAN (OPTICK_ENABLE_GPU /*&& 0*/)


### PR DESCRIPTION
Trivial change to fix the misspelling of Vulkan.