### PR TITLE
Fix deprecation warning with clang shipped with Android NDK r22b

### DIFF
--- a/src/optick_memory.h
+++ b/src/optick_memory.h
@@ -132,7 +132,7 @@ namespace Optick
 			Allocator(const Allocator<U>&) {}
 			template<typename U> struct rebind { typedef Allocator<U> other; };
 
-			typename std::allocator<T>::pointer allocate(typename std::allocator<T>::size_type n, typename std::allocator<void>::const_pointer = 0)
+			typename std::allocator<T>::pointer allocate(typename std::allocator<T>::size_type n)
 			{
 				return reinterpret_cast<typename std::allocator<T>::pointer>(Memory::Alloc(n * sizeof(T)));
 			}


### PR DESCRIPTION
Fix build warning about deprecated feature std::allocator<void> (see https://en.cppreference.com/w/cpp/memory/allocator)

The second argument isn't necessary and is also deprecated in C++17 (see https://en.cppreference.com/w/cpp/memory/allocator/allocate) so I have just removed it