### PR TITLE
Detect clang-cl as MSVC

### DIFF
--- a/src/optick.h
+++ b/src/optick.h
@@ -30,7 +30,14 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#if defined(__clang__) || defined(__GNUC__)
+#if defined(_MSC_VER)
+#	define OPTICK_MSVC (1)
+#	if defined(_DURANGO)
+#		define OPTICK_PC (0)
+#	else
+#		define OPTICK_PC (1)
+#       endif
+#elif defined(__clang__) || defined(__GNUC__)
 #	define OPTICK_GCC (1)
 #	if defined(__APPLE_CC__)
 #		define OPTICK_OSX (1)
@@ -39,13 +46,6 @@
 #	elif defined(__FreeBSD__)
 #		define OPTICK_FREEBSD (1)
 #	endif
-#elif defined(_MSC_VER)
-#	define OPTICK_MSVC (1)
-#	if defined(_DURANGO)
-#		define OPTICK_PC (0)
-#	else
-#		define OPTICK_PC (1)
-#endif
 #else
 #error Compiler not supported
 #endif


### PR DESCRIPTION
The compiler identification checks in src/optick.h currently assume the
user is on a Unix platform is compiling with Clang. This isn't the case
when using Clang's MSVC compatible frontend (clang-cl).

This is a simple fix that checks for MSVC first, which both cl.exe
and clang-cl.exe will identify as.