### PR TITLE
Fix compilation in C++20 mode

### DIFF
--- a/src/optick_memory.h
+++ b/src/optick_memory.h
@@ -132,12 +132,12 @@ namespace Optick
 			Allocator(const Allocator<U>&) {}
 			template<typename U> struct rebind { typedef Allocator<U> other; };
 
-			typename std::allocator<T>::pointer allocate(typename std::allocator<T>::size_type n, typename std::allocator<void>::const_pointer = 0)
+			typename std::allocator<T>::value_type* allocate(typename std::allocator<T>::size_type n, const typename std::allocator<void>::value_type* = 0)
 			{
-				return reinterpret_cast<typename std::allocator<T>::pointer>(Memory::Alloc(n * sizeof(T)));
+				return reinterpret_cast<typename std::allocator<T>::value_type*>(Memory::Alloc(n * sizeof(T)));
 			}
 
-			void deallocate(typename std::allocator<T>::pointer p, typename std::allocator<T>::size_type)
+			void deallocate(typename std::allocator<T>::value_type* p, typename std::allocator<T>::size_type)
 			{
 				Memory::Free(p);
 			}


### PR DESCRIPTION
std::allocator pointer and const_pointer were removed in C++20. Replacing with just adding the decorations around value_type.