### PR TITLE
Allow building static libs with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,9 +41,10 @@ option(OPTICK_USE_VULKAN "Built-in support for Vulkan" OFF)
 option(OPTICK_USE_D3D12 "Built-in support for DirectX 12" OFF)
 option(OPTICK_BUILD_GUI_APP "Build Optick gui viewer app" OFF)
 option(OPTICK_BUILD_CONSOLE_SAMPLE "Build Optick console sample app" ${standalone})
+option(BUILD_SHARED_LIBS "Build shared libraries" ON)
 
 # OptickCore
-add_library(OptickCore SHARED ${OPTICK_SRC})
+add_library(OptickCore ${OPTICK_SRC})
 target_include_directories(OptickCore
 	PUBLIC
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>


### PR DESCRIPTION
Currently you're forced to build a static lib because it's added with the `STATIC` keyword

Cmake has a built in option users can set to build shared/static called [`BUILD_SHARED_LIBS`](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html) so it would be good to allow users to decide themselves what to do

To avoid potentially breaking changes I've also added it as an option to the Optick script as the CMake default is to build static