### PR TITLE
Fix UE4 plugin: missing include and wrong location for LOCTEXT

### DIFF
--- a/samples/UnrealEnginePlugin/Source/Private/OptickPlugin.cpp
+++ b/samples/UnrealEnginePlugin/Source/Private/OptickPlugin.cpp
@@ -19,12 +19,11 @@
 // Optick
 #include "OptickUE4Classes.h"
 
-#define LOCTEXT_NAMESPACE "FOptickModule"
-
 #if WITH_EDITOR
 #include "DesktopPlatformModule.h"
 #include "EditorStyleSet.h"
 #include "Framework/Commands/Commands.h"
+#include "Framework/MultiBox/MultiBoxBuilder.h"
 #include "Editor/EditorPerformanceSettings.h"
 #include "Editor/LevelEditor/Public/LevelEditor.h"
 #include "Editor/UnrealEd/Public/SEditorViewportToolBarMenu.h"
@@ -36,6 +35,8 @@
 #endif
 
 #include <optick.h>
+
+#define LOCTEXT_NAMESPACE "FOptickModule"
 
 DEFINE_LOG_CATEGORY(OptickLog);
 


### PR DESCRIPTION
Hi,

There is a missing include in the plugin, and also LOCTEXT_NAMESPACE must always be after includes. 

-Yohann