### PR TITLE
Remove unnecessary dependency on UE4 plugin

### DIFF
--- a/samples/UnrealEnginePlugin/Source/OptickPlugin.Build.cs
+++ b/samples/UnrealEnginePlugin/Source/OptickPlugin.Build.cs
@@ -73,11 +73,9 @@ namespace UnrealBuildTool.Rules
 						"SlateCore",
 						"EditorStyle",
 						"UnrealEd",
-						"MainFrame",
 						"GameProjectGeneration",
 						"Projects",
 						"InputCore",
-						"LevelEditor",
 						"DesktopPlatform",
 					}
 				);


### PR DESCRIPTION
Hi,

There are 2 unnecessary dependency in the UE4 plugin and it causes an issue.
LevelEditor and MainFrame are not used but because LevelEditor is there, it will try to load MainFrame.
MainFrame is special module and can be loaded ONLY in the editor.
But there is a flow in unreal when you launch the editor as game (using -game).
In this scenario, MainFrame will ensure from:
`ensureMsgf(!IsRunningGame(), TEXT("The MainFrame module should only be loaded when running the editor.  Code that extends the editor, adds menu items, etc... should not run when running in -game mode or in a non-WITH_EDITOR build"));`

Because LevelEditor and MainFrame are not used, I think it's preferable to remove them.

Tested with UE 4.27.2.

-Yohann