### PR TITLE
Fix ensure coming from MainFrame module using the editor with -game

### DIFF
--- a/samples/UnrealEnginePlugin/Source/OptickPlugin.Build.cs
+++ b/samples/UnrealEnginePlugin/Source/OptickPlugin.Build.cs
@@ -73,9 +73,11 @@ namespace UnrealBuildTool.Rules
 						"SlateCore",
 						"EditorStyle",
 						"UnrealEd",
+						"MainFrame",
 						"GameProjectGeneration",
 						"Projects",
 						"InputCore",
+						"LevelEditor",
 						"DesktopPlatform",
 					}
 				);

--- a/samples/UnrealEnginePlugin/Source/Private/OptickPlugin.cpp
+++ b/samples/UnrealEnginePlugin/Source/Private/OptickPlugin.cpp
@@ -246,22 +246,25 @@ void FOptickPlugin::StartupModule()
 	Optick::SetStateChangedCallback(OnOptickStateChanged);
 
 #if WITH_EDITOR
-	FOptickStyle::Initialize();
-	FOptickStyle::ReloadTextures();
-	FOptickCommands::Register();
+	if (GIsEditor)
+	{
+		FOptickStyle::Initialize();
+		FOptickStyle::ReloadTextures();
+		FOptickCommands::Register();
 
-	PluginCommands = MakeShareable(new FUICommandList);
+		PluginCommands = MakeShareable(new FUICommandList);
 
-	PluginCommands->MapAction(
-		FOptickCommands::Get().PluginAction,
-		FExecuteAction::CreateRaw(this, &FOptickPlugin::OnOpenGUI),
-		FCanExecuteAction());
+		PluginCommands->MapAction(
+			FOptickCommands::Get().PluginAction,
+			FExecuteAction::CreateRaw(this, &FOptickPlugin::OnOpenGUI),
+			FCanExecuteAction());
 
-	FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
-	ExtensionManager = LevelEditorModule.GetToolBarExtensibilityManager();
-	ToolbarExtender = MakeShareable(new FExtender);
-	ToolbarExtension = ToolbarExtender->AddToolBarExtension("Game", EExtensionHook::After, PluginCommands, FToolBarExtensionDelegate::CreateLambda([this](FToolBarBuilder& ToolbarBuilder) { AddToolbarExtension(ToolbarBuilder); })	);
-	ExtensionManager->AddExtender(ToolbarExtender);
+		FLevelEditorModule& LevelEditorModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
+		ExtensionManager = LevelEditorModule.GetToolBarExtensibilityManager();
+		ToolbarExtender = MakeShareable(new FExtender);
+		ToolbarExtension = ToolbarExtender->AddToolBarExtension("Game", EExtensionHook::After, PluginCommands, FToolBarExtensionDelegate::CreateLambda([this](FToolBarBuilder& ToolbarBuilder) { AddToolbarExtension(ToolbarBuilder); })	);
+		ExtensionManager->AddExtender(ToolbarExtender);
+	}
 #endif
 
 #ifdef OPTICK_UE4_GPU
@@ -280,11 +283,14 @@ void FOptickPlugin::ShutdownModule()
 	StopCapture();
 
 #if WITH_EDITOR
-	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
-	// we call this function before unloading the module.
-	FOptickStyle::Shutdown();
+	if (GIsEditor)
+	{
+		// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
+		// we call this function before unloading the module.
+		FOptickStyle::Shutdown();
 
-	FOptickCommands::Unregister();
+		FOptickCommands::Unregister();
+	}
 #endif
 
 	UE_LOG(OptickLog, Display, TEXT("OptickPlugin UnLoaded!"));

--- a/samples/UnrealEnginePlugin/Source/Private/OptickStyle.cpp
+++ b/samples/UnrealEnginePlugin/Source/Private/OptickStyle.cpp
@@ -4,6 +4,7 @@
 
 #if WITH_EDITOR
 
+#include "Framework/Application/SlateApplication.h"
 #include "Slate/SlateGameResources.h"
 #include "SlateCore/Public/Styling/SlateStyleRegistry.h"
 #include "Projects/Public/Interfaces/IPluginManager.h"


### PR DESCRIPTION
Hi,

I was wrong when I wrote LevelEditor + MainFrame where unnecessary, but I was right about loading them with the editor and -game don't work.
To fix the issue, I've checked what other modules are doing.
The best option is to check for the singleton GIsEditor. In editor, it will be valid, in editor with -game or standalone, it will be nullptr.

Note: I've also fixed a missing include in OptickStyle.cpp for `FSlateApplication`

-Yohann
