### PR TITLE
Fixed issue where sockets weren't being closed.

### DIFF
--- a/src/optick_server.cpp
+++ b/src/optick_server.cpp
@@ -146,7 +146,7 @@ class Socket
 
 	void Close()
 	{
-		if (!IsValidSocket(listenSocket))
+		if (IsValidSocket(listenSocket))
 		{
 			CloseSocket(listenSocket);
 		}
@@ -170,7 +170,7 @@ class Socket
 	{
 		std::lock_guard<std::recursive_mutex> lock(socketLock);
 
-		if (!IsValidSocket(acceptSocket))
+		if (IsValidSocket(acceptSocket))
 		{
 			CloseSocket(acceptSocket);
 		}


### PR DESCRIPTION
Fixed issue where sockets weren't being closed, so Optick was unable to connect if destroyed and recreated in same process.

Noticed when using Optick inside a dll that was hot reloaded (Using a native dll in Unity).