### PR TITLE
Minor fixes for Linux compilation

### DIFF
--- a/samples/Common/TestEngine/TestEngine.cpp
+++ b/samples/Common/TestEngine/TestEngine.cpp
@@ -5,6 +5,7 @@
 #include <math.h>
 #include <vector>
 #include <cstring>
+#include <cstdio>
 
 #if OPTICK_ENABLE_FIBERS
 #include <MTProfilerEventListener.h>

--- a/src/optick.h
+++ b/src/optick.h
@@ -896,6 +896,8 @@ struct OptickApp
 													case Optick::FrameType::CPU:								\
 														::Optick::Update();										\
 														break;													\
+													default:													\
+														break;													\
 												}																\
 												::Optick::BeginFrame(FRAME_TYPE);								\
 												::Optick::Event OPTICK_CONCAT(autogen_event_, __LINE__)(*::Optick::GetFrameDescription(FRAME_TYPE));

--- a/src/optick_core.linux.h
+++ b/src/optick_core.linux.h
@@ -260,7 +260,7 @@ bool FTrace::Stop()
 		size_t len = 0;
 		while ((getline(&line, &len, pipe)) != -1)
 			Parse(line);
-		fclose(pipe);
+		pclose(pipe);
 	}
 
 	// Cleanup data


### PR DESCRIPTION
This includes a few adaptations I had to make for building on Linux without warnings (using `./tools/Linux/premake5 gmake && pushd build/gmake/ && make config=release_x64 && popd`).

- Replacing `fclose` with `pclose` fixes `../../src/optick_core.linux.h:263:23: error: ‘int fclose(FILE*)’ called on pointer returned from a mismatched allocation function [-Werror=mismatched-dealloc]`
- Adding `#include <cstdio>` fixes `../../samples/Common/TestEngine/TestEngine.cpp:274:16: error: ‘sprintf’ was not declared in this scope`
- Adding `default: break;` fixes `../../src/optick.h:895:104: error: enumeration value ‘GPU’ not handled in switch [-Werror=switch]`