### PR TITLE
Add a shutdown Vulkan function to correctly free the Vulkan resources

### DIFF
--- a/src/optick.h
+++ b/src/optick.h
@@ -763,6 +763,7 @@ struct OPTICK_API GPUContext
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 OPTICK_API void InitGpuD3D12(ID3D12Device* device, ID3D12CommandQueue** cmdQueues, uint32_t numQueues);
 OPTICK_API void InitGpuVulkan(VkDevice* vkDevices, VkPhysicalDevice* vkPhysicalDevices, VkQueue* vkQueues, uint32_t* cmdQueuesFamily, uint32_t numQueues, const VulkanFunctions* functions);
+OPTICK_API void ShutdownGpuVulkan();
 OPTICK_API void GpuFlip(void* swapChain);
 OPTICK_API GPUContext SetGpuContext(GPUContext context);
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1025,6 +1026,7 @@ struct OptickApp
 // GPU events
 #define OPTICK_GPU_INIT_D3D12(DEVICE, CMD_QUEUES, NUM_CMD_QUEUS)													::Optick::InitGpuD3D12(DEVICE, CMD_QUEUES, NUM_CMD_QUEUS);
 #define OPTICK_GPU_INIT_VULKAN(DEVICES, PHYSICAL_DEVICES, CMD_QUEUES, CMD_QUEUES_FAMILY, NUM_CMD_QUEUS, FUNCTIONS)	::Optick::InitGpuVulkan(DEVICES, PHYSICAL_DEVICES, CMD_QUEUES, CMD_QUEUES_FAMILY, NUM_CMD_QUEUS, FUNCTIONS);
+#define OPTICK_GPU_SHUTDOWN_VULKAN()																				::Optick::ShutdownGpuVulkan();
 
 // Setup GPU context:
 // Params:
@@ -1100,6 +1102,7 @@ struct OptickApp
 #define OPTICK_SHUTDOWN()
 #define OPTICK_GPU_INIT_D3D12(DEVICE, CMD_QUEUES, NUM_CMD_QUEUS)
 #define OPTICK_GPU_INIT_VULKAN(DEVICES, PHYSICAL_DEVICES, CMD_QUEUES, CMD_QUEUES_FAMILY, NUM_CMD_QUEUS, FUNCTIONS)
+#define OPTICK_GPU_SHUTDOWN_VULKAN()
 #define OPTICK_GPU_CONTEXT(...)
 #define OPTICK_GPU_EVENT(NAME)
 #define OPTICK_GPU_FLIP(SWAP_CHAIN)

--- a/src/optick_gpu.vulkan.cpp
+++ b/src/optick_gpu.vulkan.cpp
@@ -84,11 +84,18 @@ namespace Optick
 		void Flip(void* swapChain) override;
 	};
 
+	GPUProfilerVulkan* gpuProfiler = nullptr;
+
 	void InitGpuVulkan(VkDevice* vkDevices, VkPhysicalDevice* vkPhysicalDevices, VkQueue* vkQueues, uint32_t* cmdQueuesFamily, uint32_t numQueues, const VulkanFunctions* functions)
 	{
-		GPUProfilerVulkan* gpuProfiler = Memory::New<GPUProfilerVulkan>();
+		gpuProfiler = Memory::New<GPUProfilerVulkan>();
 		gpuProfiler->InitDevice(vkDevices, vkPhysicalDevices, vkQueues, cmdQueuesFamily, numQueues, functions);
 		Core::Get().InitGPUProfiler(gpuProfiler);
+	}
+
+	void ShutdownGpuVulkan()
+	{
+		Memory::Delete<GPUProfilerVulkan>(gpuProfiler);
 	}
 
 	GPUProfilerVulkan::GPUProfilerVulkan()


### PR DESCRIPTION
When closing a Vulkan based application, there will be some validation errors due to the optick resources. Would be called like so:

```
void ShutdownVulkan()
{
#ifdef MIRAGE_CAPTURE_WITH_OPTICK
	OPTICK_GPU_SHUTDOWN_VULKAN();
#endif

//the rest of vulkan shutting down
}
```

this pull related to #121