### PR TITLE
Add a shutdown D3D12 function to correctly free the D3D12 resources

### DIFF
--- a/src/optick.h
+++ b/src/optick.h
@@ -763,6 +763,7 @@ struct OPTICK_API GPUContext
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 OPTICK_API void InitGpuD3D12(ID3D12Device* device, ID3D12CommandQueue** cmdQueues, uint32_t numQueues);
 OPTICK_API void InitGpuVulkan(VkDevice* vkDevices, VkPhysicalDevice* vkPhysicalDevices, VkQueue* vkQueues, uint32_t* cmdQueuesFamily, uint32_t numQueues, const VulkanFunctions* functions);
+OPTICK_API void ShutdownGpuD3D12();
 OPTICK_API void GpuFlip(void* swapChain);
 OPTICK_API GPUContext SetGpuContext(GPUContext context);
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1025,6 +1026,7 @@ struct OptickApp
 // GPU events
 #define OPTICK_GPU_INIT_D3D12(DEVICE, CMD_QUEUES, NUM_CMD_QUEUS)													::Optick::InitGpuD3D12(DEVICE, CMD_QUEUES, NUM_CMD_QUEUS);
 #define OPTICK_GPU_INIT_VULKAN(DEVICES, PHYSICAL_DEVICES, CMD_QUEUES, CMD_QUEUES_FAMILY, NUM_CMD_QUEUS, FUNCTIONS)	::Optick::InitGpuVulkan(DEVICES, PHYSICAL_DEVICES, CMD_QUEUES, CMD_QUEUES_FAMILY, NUM_CMD_QUEUS, FUNCTIONS);
+#define OPTICK_GPU_SHUTDOWN_D3D12()																					::Optick::ShutdownGpuD3D12();
 
 // Setup GPU context:
 // Params:
@@ -1100,6 +1102,7 @@ struct OptickApp
 #define OPTICK_SHUTDOWN()
 #define OPTICK_GPU_INIT_D3D12(DEVICE, CMD_QUEUES, NUM_CMD_QUEUS)
 #define OPTICK_GPU_INIT_VULKAN(DEVICES, PHYSICAL_DEVICES, CMD_QUEUES, CMD_QUEUES_FAMILY, NUM_CMD_QUEUS, FUNCTIONS)
+#define OPTICK_GPU_SHUTDOWN_D3D12()
 #define OPTICK_GPU_CONTEXT(...)
 #define OPTICK_GPU_EVENT(NAME)
 #define OPTICK_GPU_FLIP(SWAP_CHAIN)

--- a/src/optick_gpu.d3d12.cpp
+++ b/src/optick_gpu.d3d12.cpp
@@ -124,11 +124,18 @@ namespace Optick
 		}
 	}
 
+	GPUProfilerD3D12* gpuProfiler = nullptr;
+
 	void InitGpuD3D12(ID3D12Device* device, ID3D12CommandQueue** cmdQueues, uint32_t numQueues)
 	{
-		GPUProfilerD3D12* gpuProfiler = Memory::New<GPUProfilerD3D12>();
+		gpuProfiler = Memory::New<GPUProfilerD3D12>();
 		gpuProfiler->InitDevice(device, cmdQueues, numQueues);
 		Core::Get().InitGPUProfiler(gpuProfiler);
+	}
+
+	void ShutdownGpuD3D12()
+	{
+		Memory::Delete<GPUProfilerD3D12>(gpuProfiler);
 	}
 
 	GPUProfilerD3D12::GPUProfilerD3D12() :  queryBuffer(nullptr), device(nullptr)


### PR DESCRIPTION
When closing a D3D12 based application, there will be some errors due to the optick resources. Would be called like so:

```
void ShutdownD3D12()
{
#ifdef WITH_OPTICK
	OPTICK_GPU_SHUTDOWN_D3D12();
#endif

//the rest of d3d12 shutting down
}
```
this pull related to https://github.com/bombomby/optick/issues/121