### PR TITLE
UE Plugin: fix deadlock in FOptickPlugin::StopCapture

### DIFF
--- a/samples/UnrealEnginePlugin/Source/Private/OptickPlugin.cpp
+++ b/samples/UnrealEnginePlugin/Source/Private/OptickPlugin.cpp
@@ -147,6 +147,7 @@ bool FOptickPlugin::Tick(float DeltaTime)
 	//static const FString OptickMessage(TEXT("OptickPlugin is running!"));
 	//GEngine->AddOnScreenDebugMessage(31313, 5.f, FColor::Yellow, OptickMessage);
 
+	FScopeLock ScopeLock(&UpdateCriticalSection);
 	Optick::Update();
 	return true;
 }


### PR DESCRIPTION
This PR fixes an issue described here: https://github.com/bombomby/optick/issues/170

Optick::Update acquires coreLock and then tries to acquire UpdateCriticalSection lock if the capture has been stopped, while FOptickPlugin::OnEndFrameRT locks UpdateCriticalSection first and then tries to acquire coreLock, which results in a deadlock.

The proposed solution is to acquire UpdateCriticalSection lock each time coreLock is about to be acquired