### PR TITLE
Fix crash in MemoryPool

### DIFF
--- a/src/optick_memory.h
+++ b/src/optick_memory.h
@@ -384,12 +384,19 @@ namespace Optick
 
 		const_iterator begin() const
 		{
-			return const_iterator(root, root ? 0 : SIZE);
+			return const_iterator(root, 0);
 		}
 
 		const_iterator end() const
 		{
-			return const_iterator(chunk, index);
+			if (index >= SIZE)
+			{
+			    return const_iterator(chunk ? chunk->next : nullptr, 0);
+			}
+			else
+			{
+			    return const_iterator(chunk, index);
+			}
 		}
 
 		template<class Func>


### PR DESCRIPTION
When range-iterating MemoryPool, when there are exactly N x SIZE records, the iterator will fail to stop at last block and continue reading from nullptr chunk.

This typically crashes at SaveCapture -> DumpFrames -> DumpSummary when reading frames.
https://github.com/bombomby/optick/blob/master/src/optick_core.cpp#L1134

Simple reproduction
```
Optick::StartCapture();
for (128)
{
   RecordFrame();
}
Optick::SaveCapture();


```

